### PR TITLE
Update tallyarbiter-m5atom.ino

### DIFF
--- a/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -22,11 +22,11 @@ Preferences preferences;
 */
 
 //Wifi SSID and password
-const char * networkSSID = "YourNetwork";
-const char * networkPass = "YourPassword";
+const char * networkSSID = "Buster";
+const char * networkPass = "$h@b@ng_@12";
 
 //Tally Arbiter Server
-const char * tallyarbiter_host = "TALLYARBITERSERVERIP";
+const char * tallyarbiter_host = "192.168.1.234";
 const int tallyarbiter_port = 4455;
 
 //Local Default Camera Number

--- a/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -530,6 +530,8 @@ void loop()
   // handle reconnecting if disconnected
   if (isReconnecting)
   {
+	unsigned long currentTime = millis();
+	  
     if (currentTime - currentReconnectTime >= reconnectInterval)
     {
       Serial.println("trying to re-connect with server");


### PR DESCRIPTION
Added reconnect logic. This requires adding a call to disconnect() to the SocketIOClient.cpp file (https://github.com/timum-viw/socket.io-client/blob/master/SocketIoClient.cpp) after line 32 to trigger the disconnect event when the socket receives a Disconnect message.

This allows the listener to recover from power events or network disconnects, once disconnected, it will try to connect back to the TallyArbiter server every 5 seconds by default.